### PR TITLE
Update deckgrid.js

### DIFF
--- a/src/deckgrid.js
+++ b/src/deckgrid.js
@@ -96,7 +96,7 @@ angular.module('akoenig.deckgrid').factory('Deckgrid', [
                     i        = 0,
                     selector = '';
 
-                if (!rule.media && angular.isUndefined(rule.cssRules)) {
+                if (!rule.media || angular.isUndefined(rule.cssRules)) {
                     return false;
                 }
 


### PR DESCRIPTION
It seems like this should be an OR, not an AND.  If rule.cssRules is undefined, we should always exit, correct?  Otherwise, the next statement, i = rule.cssRules.length - 1, throws an error.
