### PR TITLE
Multiple grids on page with cardTemplateString use the last template available

### DIFF
--- a/src/descriptor.js
+++ b/src/descriptor.js
@@ -42,6 +42,8 @@ angular.module('akoenig.deckgrid').factory('DeckgridDescriptor', [
             this.$$deckgrid = null;
             this.transclude = true;
             this.link = this.$$link.bind(this);
+            
+            this.templateKeyIndex = 0;
         }
 
         /**
@@ -63,6 +65,8 @@ angular.module('akoenig.deckgrid').factory('DeckgridDescriptor', [
          */
         Descriptor.prototype.$$link = function $$link (scope, elem, attrs, nullController, transclude) {
             scope.$on('$destroy', this.$$destroy.bind(this));
+            
+            var templateKey = 'deckgrid/innerHtmlTemplate' + (++this.templateKeyIndex);
 
             if (attrs.cardtemplate === undefined) {
                 if (attrs.cardtemplatestring === undefined) {
@@ -81,17 +85,17 @@ angular.module('akoenig.deckgrid').factory('DeckgridDescriptor', [
                             }
                         }
 
-                        $templateCache.put('innerHtmlTemplate', extractedInnerHTML.join());
+                        $templateCache.put(templateKey, extractedInnerHTML.join());
                     });
                 } else {
                     // use the provided template string
                     //
                     // note: the attr is accessed via the elem object, as the attrs content
                     // is already compiled and thus lacks the {{...}} expressions
-                    $templateCache.put('innerHtmlTemplate', elem.attr('cardtemplatestring'));
+                    $templateCache.put(templateKey, elem.attr('cardtemplatestring'));
                 }
 
-                scope.cardTemplate = 'innerHtmlTemplate';
+                scope.cardTemplate = templateKey;
             } else {
                 // use the provided template file
                 scope.cardTemplate = attrs.cardtemplate;


### PR DESCRIPTION
http://plnkr.co/edit/SPdgpMOZzwYbDcBqN8pn?p=preview

``` html
<div deckgrid source="[1,2,3]" cardTemplateString="aaa" class="deckgrid"></div>
<hr>
<div deckgrid source="[1,2,3,4]" cardTemplateString="bbb" class="deckgrid"></div>
<hr>
<div deckgrid source="[1,2,3,4,5,6,7]" cardTemplateString="ccc" class="deckgrid"></div>
<hr>
<div deckgrid source="[1,2,3,4,5,6,7,8]" cardTemplate="tpl1.html" class="deckgrid"></div>
<hr>
<div deckgrid source="[1,2,3,4,5,6,7,8]" cardTemplate="tpl2.html" class="deckgrid"></div>
<hr>
<div deckgrid source="[1,2,3,4,5,6,7]" cardTemplateString="ddd" class="deckgrid"></div>
```

Expected: templates aaa, bbb and ccc also displayed.
Actual result: all templates are ddd
