### PR TITLE
Add .html extension to template name

### DIFF
--- a/src/descriptor.js
+++ b/src/descriptor.js
@@ -69,7 +69,7 @@ angular.module('akoenig.deckgrid').factory('DeckgridDescriptor', [
          *
          */
         Descriptor.prototype.$$link = function $$link (scope, elem, attrs, nullController, transclude) {
-            var templateKey = 'deckgrid/innerHtmlTemplate' + (++this.$$templateKeyIndex);
+            var templateKey = 'deckgrid/innerHtmlTemplate' + (++this.$$templateKeyIndex) + '.html';
 
             scope.$on('$destroy', this.$$destroy.bind(this));
 


### PR DESCRIPTION
Http interceptors runs before template cache and without this extension it is impossible (ok, just not pretty) to distinguish if request is for template or for some data from back-end. Angular-ui plugins are doing this way so I think it might be some convention.

My problem:
I'm building app and communication with back-end is via API, so to each api request I'm adding prefix 'http://qwe.com/api/v3/'

I think this pull request might have huge impact on whole plugin and +1000 stars immediately
Anyway, great work! ; )
