### PR TITLE
Columns not rendering on model change

### DIFF
--- a/angular-deckgrid.js
+++ b/angular-deckgrid.js
@@ -387,7 +387,7 @@ angular.module('akoenig.deckgrid').factory('Deckgrid', [
             newModel = newModel || [];
             oldModel = oldModel || [];
 
-            if (oldModel.length !== newModel.length) {
+            if (!angular.equals(oldModel, newModel)) {
                 self.$$createColumns();
             }
         };


### PR DESCRIPTION
Changed the model $watch to use `angular.equals` instead of `.length` to check if the collection has changed.

This was causing problems for me if the collection changed but had the same length. (I'm using deckgrid for search results where the number of results can be the same)
