### PR TITLE
Improve performance

### DIFF
--- a/src/deckgrid.js
+++ b/src/deckgrid.js
@@ -133,6 +133,12 @@ angular.module('akoenig.deckgrid').factory('Deckgrid', [
             return mediaQueries;
         };
 
+        Deckgrid.prototype.$$cachedParams = function $$cachedParams (column) {
+            if (!this.$$cache) this.$$cache = {};
+            if (this.$$cache.column == column) return this.$$cache;
+            this.$$cache = { column: column, modelLength: 0 }
+            return this.$$cache;
+        }
         /**
          * @private
          *
@@ -147,25 +153,32 @@ angular.module('akoenig.deckgrid').factory('Deckgrid', [
          *
          */
         Deckgrid.prototype.$$createColumns = function $$createColumns () {
-            var self = this;
-
             if (!this.$$scope.layout) {
                 return $log.error('angular-deckgrid: No CSS configuration found (see ' +
-                                   'https://github.com/akoenig/angular-deckgrid#the-grid-configuration)');
+                                'https://github.com/akoenig/angular-deckgrid#the-grid-configuration)');
             }
 
-            this.$$scope.columns = [];
+            var cachedParams = this.$$cachedParams(this.$$scope.layout.columns);
+            if (cachedParams.modelLength == 0) {
+              // layout change, reset columns
+              this.$$scope.columns = [];
+            }
 
-            angular.forEach(this.$$scope.model, function onIteration (card, index) {
-                var column = (index % self.$$scope.layout.columns) | 0;
+            var modelLength = 0;
+            if (this.$$scope.model) { modelLength = this.$$scope.model.length }
 
-                if (!self.$$scope.columns[column]) {
-                    self.$$scope.columns[column] = [];
+            for (var index = cachedParams.modelLength; index < modelLength; index++) {
+                var card = this.$$scope.model[index];
+                var column = (index % this.$$scope.layout.columns) | 0;
+
+                if (!this.$$scope.columns[column]) {
+                    this.$$scope.columns[column] = [];
                 }
 
-                card.$index = index;
-                self.$$scope.columns[column].push(card);
-            });
+                this.$$scope.columns[column].push(card);
+            }
+
+            cachedParams.modelLength = modelLength;
         };
 
         /**


### PR DESCRIPTION
In this pull request, I switch to $watchCollection to gain a bit more performance over deep $watch ($watch with third params set to true). Also I added some caching to column calculation to avoid recreate columns every time. It does take into assumption that no item being removed from the source, only added, which is the case for most lazy loading site. I can feel that the grid is now render much faster compare to the original one. Thanks @mikenikles for pointing me at the $$createColumns function. 
