### PR TITLE
Fixes error when layout is not defined

### DIFF
--- a/angular-deckgrid.js
+++ b/angular-deckgrid.js
@@ -363,16 +363,18 @@ angular.module('akoenig.deckgrid').factory('Deckgrid', [
             var self = this,
                 layout = this.$$getLayout();
 
-            //
-            // Okay, the layout has changed.
-            // Creating a new column structure is not avoidable.
-            //
-            if (layout.columns !== this.$$scope.layout.columns) {
-                self.$$scope.layout = layout;
-
-                self.$$scope.$apply(function onApply () {
-                    self.$$createColumns();
-                });
+            if (layout !== undefined) {
+                //
+                // Okay, the layout has changed.
+                // Creating a new column structure is not avoidable.
+                //
+                if (layout.columns !== this.$$scope.layout.columns) {
+                    self.$$scope.layout = layout;
+    
+                    self.$$scope.$apply(function onApply () {
+                        self.$$createColumns();
+                    });
+                }
             }
         };
 


### PR DESCRIPTION
On both Chrome and Safari on mobile when the media query changes sometimes the layout isn't defined yet and the method errors out. It looks like another media query event still fires after the DOM is loaded with the template data so in the end everything is ok. But since I have sentry hooked up, I'm trying to silence errors.  The sentry dump is below.

I just simply added a check to make sure the layout is defined before proceeding.

```
{
  "id": "adee235a5be64510bf22dc677d0e1dda",
  "culprit": "app-e0a37f1\/components\/angular-deckgrid\/angular-deckgrid in Deckgrid.$$onMediaQueryChange",
  "message": "Cannot read property 'columns' of undefined",
  "checksum": "d7e1d0be10c97435ac1201218a339dfc",
  "project": "frontend-dailyreaderme",
  "datetime": "2015-05-14T20:52:19.000000Z",
  "time_spent": null,
  "extra": {
    
  },
  "sentry.interfaces.Exception": {
    "exc_omitted": null,
    "values": [
      {
        "stacktrace": {
          "frames": [
            {
              "function": "Deckgrid.$$onMediaQueryChange",
              "abs_path": "https:\/\/www.dailyreader.me\/app-e0a37f1\/components\/angular-deckgrid\/angular-deckgrid.js",
              "pre_context": [
                "",
                "            \/\/",
                "            \/\/ Okay, the layout has changed.",
                "            \/\/ Creating a new column structure is not avoidable.",
                "            \/\/"
              ],
              "post_context": [
                "                self.$$scope.layout = layout;",
                "",
                "                self.$$scope.$apply(function onApply () {",
                "                    self.$$createColumns();",
                "                });"
              ],
              "filename": "\/app-e0a37f1\/components\/angular-deckgrid\/angular-deckgrid.js",
              "module": "app-e0a37f1\/components\/angular-deckgrid\/angular-deckgrid",
              "colno": 23,
              "in_app": true,
              "context_line": "            if (layout.columns !== this.$$scope.layout.columns) {",
              "lineno": 370
            }
          ],
          "frames_omitted": null
        },
        "type": "TypeError",
        "value": "Cannot read property 'columns' of undefined",
        "module": null
      }
    ]
  },
  "sentry.interfaces.Http": {
    "url": "https:\/\/www.dailyreader.me\/stream\/category\/texas",
    "headers": {
      "User-Agent": "Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/44.0.2401.0 Safari\/537.36"
    }
  },
  "sentry.interfaces.User": {
    "ip_address": "99.103.57.30"
  },
  "tags": [
    [
      "level",
      "error"
    ],
    [
      "logger",
      "javascript"
    ],
    [
      "browser",
      "Chrome 44.0"
    ],
    [
      "device",
      "Other"
    ],
    [
      "os",
      "Mac OS X 10.10.4"
    ],
    [
      "url",
      "https:\/\/www.dailyreader.me\/stream\/category\/texas"
    ]
  ],
  "version": 4
}
```