### PR TITLE
Update "The responsiveness" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ The grid items will be distributed by your configured CSS selectors. An example:
 
 In order to support different grid representations for different screen sizes, you can define the respective media queries like:
 
+    .deckgrid .column-1-1 {
+        width: 100%;
+    }
+
     @media screen and (max-width: 480px){
         .deckgrid[deckgrid]::before {
             content: '1 .column.column-1-1';
-        }
-
-        .deckgrid .column-1-1 {
-            width: 100%;
         }
     }
     ...


### PR DESCRIPTION
Column size should be defined outside the media query to avoid flickering effect when triggered.

For exemple, the folowing code causes a flickering effect when the screen width goes from 991px to 992px (tested on Chrome version 42).

```css
@media (max-width: 991px) {
    .deckgrid[deckgrid]::before {
        content: '2 .column.column-1-2';
    }
   .deckgrid .column-1-2 {
       width: 50%;
   }
}

@media (min-width: 992px) {
    .deckgrid[deckgrid]::before {
        content: '3 .column.column-1-3';
    }
   .deckgrid .column-1-3 {
       width: 33.33%;
   }
}
```