### PR TITLE
Fix a bug about destroy

### DIFF
--- a/angular-deckgrid.js
+++ b/angular-deckgrid.js
@@ -81,24 +81,11 @@ angular.module('akoenig.deckgrid').factory('DeckgridDescriptor', [
         /**
          * @private
          *
-         * Cleanup method. Will be called when the
-         * deckgrid directive should be destroyed.
-         *
-         */
-        Descriptor.prototype.$$destroy = function $$destroy () {
-            this.$$deckgrid.destroy();
-        };
-
-        /**
-         * @private
-         *
          * The deckgrid link method. Will instantiate the deckgrid.
          *
          */
         Descriptor.prototype.$$link = function $$link (scope, elem, attrs, nullController, transclude) {
             var templateKey = 'deckgrid/innerHtmlTemplate' + (++this.$$templateKeyIndex) + '.html';
-
-            scope.$on('$destroy', this.$$destroy.bind(this));
 
             if (angular.isUndefined(attrs.cardtemplate)) {
                 if (angular.isUndefined(attrs.cardtemplatestring)) {
@@ -136,6 +123,8 @@ angular.module('akoenig.deckgrid').factory('DeckgridDescriptor', [
             scope.mother = scope.$parent;
 
             this.$$deckgrid = Deckgrid.create(scope, elem[0]);
+            
+            scope.$on('$destroy', this.$$deckgrid.destroy.bind(this.$$deckgrid));
         };
 
         return {


### PR DESCRIPTION
Bug: when we switch from one state (page) to another, and we have deckgrid in both states, then new deckgrid is created, then destroy is called... but is called for just created new deckgrid instead of old one.

Reason: angular calls directive function only once. So that we always have the only instance of Descriptor (and several inctances of Deckgrid). Hence, descriptor.$$deckgrid will always point to the recently assigned deckgrid.

Fix: instead of using $$destroy in Descriptor (that has one instance only), use destroy of deckgrid directly (specifying correct instance of DeckGrid, so that I bind it to just created instance of DeckGrid in $$link function).
