### PR TITLE
Fix commas being inserted into templates.

### DIFF
--- a/src/descriptor.js
+++ b/src/descriptor.js
@@ -90,7 +90,7 @@ angular.module('akoenig.deckgrid').factory('DeckgridDescriptor', [
                             }
                         }
 
-                        $templateCache.put(templateKey, extractedInnerHTML.join());
+                        $templateCache.put(templateKey, extractedInnerHTML.join(""));
                     });
                 } else {
                     // use the provided template string


### PR DESCRIPTION
`Array.prototype.join()`'s default behavior is to join with `","`, rather than an empty string. By explicitly specifying an empty string, this should fix commas being inserted into deckgrid templates with multiple innerHTML transclusion elements. 